### PR TITLE
Fix shared build on --enable-snaphot-build, change --with into --enable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,22 @@ environment:
       INT_SIZE: 32
       PHP_VER: 7.2
       VC_VER: vc15
+      ZTS: --enable-zts
     - ARCH: x64
       INT_SIZE: 64
       PHP_VER: 7.2
       VC_VER: vc15
+      ZTS: --enable-zts
+    - ARCH: x86
+      INT_SIZE: 32
+      PHP_VER: 7.2
+      VC_VER: vc15
+      ZTS: --disable-zts
+    - ARCH: x64
+      INT_SIZE: 64
+      PHP_VER: 7.2
+      VC_VER: vc15
+      ZTS: --disable-zts
 
 install:
 - cmd: cinst wget
@@ -48,7 +60,7 @@ build_script:
 
     buildconf.bat
 
-    configure.bat --disable-all --with-openssl --with-ds --enable-json --enable-cli --enable-zts --with-prefix=C:\projects\php-ds\bin --with-php-build=deps --enable-ipv6
+    cscript /nologo configure.js --enable-snapshot-build --enable-crt-debug %ZTS% --with-prefix=C:\projects\php-ds\bin --with-php-build=deps
 
     nmake
 
@@ -71,10 +83,7 @@ build_script:
     php -m
 
 test_script:
-- cmd: cd C:\projects\php-ds
-- cmd: C:\projects\php-ds\bin\php.exe C:\projects\php-ds\bin\composer.phar update --prefer-source
-- cmd: C:\projects\php-ds\bin\php.exe test.php
-
+- cmd: php.exe /projects/php-src/run-tests.php /projects/php-src/ext/ds -q --show-diff
 artifacts:
   - path: bin
     name: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ build_script:
 
     buildconf.bat
 
-    cscript /nologo configure.js --enable-snapshot-build --enable-crt-debug %ZTS% --with-prefix=C:\projects\php-ds\bin --with-php-build=deps
+    cscript /nologo configure.js --disable-all --enable-cli %ZTS% --with-openssl --enable-ds=shared --enable-json=static --with-prefix=C:\projects\php-ds\bin --with-php-build=deps
 
     nmake
 

--- a/config.w32
+++ b/config.w32
@@ -1,3 +1,5 @@
+// vim:ft=javascript
+
 var DS_EXT_NAME="ds";
 var DS_EXT_DIR="ext/ds/src";
 var DS_EXT_API="php_ds.c";
@@ -12,9 +14,9 @@ function ds_src(dir, files) {
 }
 
 ////////////////////////////////////
-ARG_WITH("ds", "for extended data structure support", "yes");
+ARG_ENABLE("ds", "for extended data structure support", "no");
 
-if (PHP_DS == "yes") {
+if (PHP_DS != "no") {
 	EXTENSION(DS_EXT_NAME, DS_EXT_API, PHP_DS_SHARED, DS_EXT_FLAGS);
 
     ds_src("/",


### PR DESCRIPTION
When PHP is built with --enable-snapshot-build with this repo cloned in ext/ds ds is compiled as static. This PR reverts the changes in the no/yes handling.
See also https://github.com/php-ds/ext-ds/commit/844d7b1061bd78f51f3038c50143092e47f796d8#commitcomment-31395019

The PR also changes ARG_WITH into ARG_ENABLE. The convention is that --with is used for extensions with external libs and --enable for self-contained extensions