### PR TITLE
travis: test php 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - nightly
 
 matrix:


### PR DESCRIPTION
the `nightly` is actually php 8.0, see https://travis-ci.org/php-ds/ext-ds/jobs/549029626#L442

the 7.4 currently is available under `7.4snapshot`:
- https://travis-ci.community/t/add-php-7-4-branch-to-test-against/2179 