### PR TITLE
Queue & Set should implement ArrayAccess

### DIFF
--- a/src/php/classes/php_queue_ce.c
+++ b/src/php/classes/php_queue_ce.c
@@ -152,7 +152,11 @@ void php_ds_register_queue()
     php_ds_queue_ce->unserialize    = php_ds_queue_unserialize;
 
     zend_declare_class_constant_long(php_ds_queue_ce, STR_AND_LEN("MIN_CAPACITY"), DS_DEQUE_MIN_CAPACITY);
-    zend_class_implements(php_ds_queue_ce, 1, collection_ce);
+
+    zend_class_implements(php_ds_queue_ce, 2,
+        collection_ce,
+        zend_ce_arrayaccess
+    );
 
     php_ds_register_queue_handlers();
 }

--- a/src/php/classes/php_set_ce.c
+++ b/src/php/classes/php_set_ce.c
@@ -309,6 +309,10 @@ void php_ds_register_set()
         DS_HTABLE_MIN_CAPACITY
     );
 
-    zend_class_implements(php_ds_set_ce, 1, collection_ce);
+    zend_class_implements(php_ds_set_ce, 2,
+        collection_ce,
+        zend_ce_arrayaccess
+    );
+
     php_ds_register_set_handlers();
 }


### PR DESCRIPTION
As mentioned in https://github.com/php-ds/polyfill/issues/72, `Queue` and `Set` implement `ArrayAccess` methods, but don't report it.