### PR TITLE
Support phpize builds on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,7 +1,7 @@
 // vim:ft=javascript
 
 var DS_EXT_NAME="ds";
-var DS_EXT_DIR="ext/ds/src";
+var DS_EXT_DIR=configure_module_dirname + "/src";
 var DS_EXT_API="php_ds.c";
 var DS_EXT_FLAGS="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /I" + configure_module_dirname;
 


### PR DESCRIPTION
phpize builds are usually done out-tree, so the hard-coded path name
ext/ds won't work.