### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: PHP ${{ matrix.php }} ZTS ${{ matrix.zts }} OPcache ${{ matrix.opcache }}
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           - 7.4.14
           - 8.0.1
         zts: [on, off]
-
+        opcache: [on, off]
     steps:
       - uses: actions/checkout@v2
 
@@ -56,6 +56,9 @@ jobs:
 
       - name: Prefix PHP to PATH
         run: echo "${{ github.workspace }}/php/bin" >> $GITHUB_PATH
+
+      - name: Generate OPcache configuration
+        run: echo "opcache.enable_cli=${{ matrix.opcache }}" >> ${{ github.workspace }}/php/etc/conf.d/opcache.ini
 
       - name: Install Composer
         run: curl -sS https://getcomposer.org/installer | php

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/php-build
           ./install-dependencies.sh
-          PHP_BUILD_ZTS_ENABLE=${{ matrix.zts }} ./bin/php-build ${{ matrix.php }} ${{ github.workspace}}/php
+          PHP_BUILD_ZTS_ENABLE=${{ matrix.zts }} ./bin/php-build ${{ matrix.php }} ${{ github.workspace }}/php
 
       - name: Install extension
         run: |
@@ -54,6 +54,7 @@ jobs:
           ./configure --with-php-config=${{ github.workspace }}/php/bin/php-config
           make -j8 install
           echo "extension=ds.so" > ${{ github.workspace }}/php/etc/conf.d/ds.ini
+          rm ${{ github.workspace }}/php/etc/conf.d/xdebug.ini || true
 
       - name: Prefix PHP to PATH
         run: echo "${{ github.workspace }}/php/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,13 @@ jobs:
           key: php-build-${{ matrix.php }}-zts-${{ matrix.zts }}
 
       - name: Clone php-build/php-build
-        if: steps.php-build-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: php-build/php-build
           path: ${{ github.workspace }}/php-build
+
+      - name: Install PHP dependencies
+        run: ${{ github.workspace }}/php-build/install-dependencies.sh
 
       - name: Compile PHP
         if: steps.php-build-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         run: echo "${{ github.workspace }}/php/bin" >> $GITHUB_PATH
 
       - name: Generate OPcache configuration
-        run: echo "opcache.enable_cli=${{ matrix.opcache }}" >> ${{ github.workspace }}/php/etc/conf.d/opcache.ini
+        run: echo "opcache.enable_cli=${{ matrix.opcache }}" > ${{ github.workspace }}/php/etc/conf.d/opcache.ini
 
       - name: Install Composer
         run: curl -sS https://getcomposer.org/installer | php

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - 7.1.33
+          - 7.2.34
+          - 7.3.26
+          - 7.4.14
+          - 8.0.1
+        zts: [on, off]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Restore PHP build cache
+        id: php-build-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/php
+          key: php-build-${{ matrix.php }}-zts-${{ matrix.zts }}
+
+      - name: Clone php-build/php-build
+        if: steps.php-build-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: php-build/php-build
+          path: ${{ github.workspace }}/php-build
+
+      - name: Compile PHP
+        if: steps.php-build-cache.outputs.cache-hit != 'true'
+        run: |
+          cd ${{ github.workspace }}/php-build
+          ./install-dependencies.sh
+          PHP_BUILD_ZTS_ENABLE=${{ matrix.zts }} ./bin/php-build ${{ matrix.php }} ${{ github.workspace}}/php
+
+      - name: Install extension
+        run: |
+          cd ${{ github.workspace }}
+          ${{ github.workspace }}/php/bin/phpize
+          ./configure --with-php-config=${{ github.workspace }}/php/bin/php-config
+          make -j8 install
+          echo "extension=ds.so" > ${{ github.workspace }}/php/etc/conf.d/ds.ini
+
+      - name: Prefix PHP to PATH
+        run: echo "${{ github.workspace }}/php/bin" >> $GITHUB_PATH
+
+      - name: Install Composer
+        run: curl -sS https://getcomposer.org/installer | php
+      - name: Restore Composer package cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/composer/files
+            ~/.cache/composer/vcs
+          key: "composer-v2-cache-${{ matrix.php }}-${{ hashFiles('./composer.json') }}"
+          restore-keys: |
+            composer-v2-cache-
+
+      - name: Install Composer dependencies
+        run: php composer.phar install --prefer-dist --no-interaction
+
+      - name: Run PHPUnit tests
+        run: php composer.phar test


### PR DESCRIPTION
Travis CI have decided to screw OSS devs, so it's time to move to something else.

This tests 7.1-8.0, although 8.0 is currently failing because of incompatible test dependencies.
7.0 is not tested because it turned out to be a pain in the ass to get 7.0 to build.

This uses [php-build/php-build](https://github.com/php-build/php-build) to build PHP for testing.