### PR TITLE
ci: disable on cron schedule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - "master"
-  schedule:
-    - cron: "42 3 * * *"
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
After some time on inactivity in the repo it disables the action so it has to be manually enabled. Meanwhile it's not running for new PRs