### PR TITLE
Allow passing `null` as `$length` to `slice()` methods

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -216,6 +216,10 @@ int name##_unserialize(                 \
     zend_ce_type_error, \
     "Index must be of type integer, %s given", zend_get_type_by_const(Z_TYPE_P(z)))
 
+#define INTEGER_LENGTH_REQUIRED(z) ds_throw_exception( \
+    zend_ce_type_error, \
+    "Length must be of type integer, %s given", zend_get_type_by_const(Z_TYPE_P(z)))
+
 #define ITERATION_BY_REF_NOT_SUPPORTED() ds_throw_exception( \
     zend_ce_error, \
     "Iterating by reference is not supported")

--- a/src/php/classes/php_deque_ce.c
+++ b/src/php/classes/php_deque_ce.c
@@ -85,11 +85,15 @@ METHOD(slice)
 {
     ds_deque_t *deque = THIS_DS_DEQUE();
 
-    if (ZEND_NUM_ARGS() > 1) {
-        PARSE_LONG_AND_LONG(index, length);
-        RETURN_DS_DEQUE(ds_deque_slice(deque, index, length));
+    PARSE_LONG_AND_OPTIONAL_ZVAL(index, length);
+
+    if (ZEND_NUM_ARGS() > 1 && Z_TYPE_P(length) != IS_NULL) {
+        if (Z_TYPE_P(length) != IS_LONG) {
+            INTEGER_LENGTH_REQUIRED(length);
+        } else {
+            RETURN_DS_DEQUE(ds_deque_slice(deque, index, Z_LVAL_P(length)));
+        }
     } else {
-        PARSE_LONG(index);
         RETURN_DS_DEQUE(ds_deque_slice(deque, index, deque->size));
     }
 }

--- a/src/php/classes/php_map_ce.c
+++ b/src/php/classes/php_map_ce.c
@@ -246,11 +246,15 @@ METHOD(slice)
 {
     ds_map_t *map = THIS_DS_MAP();
 
-    if (ZEND_NUM_ARGS() > 1) {
-        PARSE_LONG_AND_LONG(index, length);
-        RETURN_DS_MAP(ds_map_slice(map, index, length));
+    PARSE_LONG_AND_OPTIONAL_ZVAL(index, length);
+
+    if (ZEND_NUM_ARGS() > 1 && Z_TYPE_P(length) != IS_NULL) {
+        if (Z_TYPE_P(length) != IS_LONG) {
+            INTEGER_LENGTH_REQUIRED(length);
+        } else {
+            RETURN_DS_MAP(ds_map_slice(map, index, Z_LVAL_P(length)));
+        }
     } else {
-        PARSE_LONG(index);
         RETURN_DS_MAP(ds_map_slice(map, index, DS_MAP_SIZE(map)));
     }
 }

--- a/src/php/classes/php_set_ce.c
+++ b/src/php/classes/php_set_ce.c
@@ -178,11 +178,15 @@ METHOD(slice)
 {
     ds_set_t *set = THIS_DS_SET();
 
-    if (ZEND_NUM_ARGS() > 1) {
-        PARSE_LONG_AND_LONG(index, length);
-        RETURN_DS_SET(ds_set_slice(set, index, length));
+    PARSE_LONG_AND_OPTIONAL_ZVAL(index, length);
+
+    if (ZEND_NUM_ARGS() > 1 && Z_TYPE_P(length) != IS_NULL) {
+        if (Z_TYPE_P(length) != IS_LONG) {
+            INTEGER_LENGTH_REQUIRED(length);
+        } else {
+            RETURN_DS_SET(ds_set_slice(set, index, Z_LVAL_P(length)));
+        }
     } else {
-        PARSE_LONG(index);
         RETURN_DS_SET(ds_set_slice(set, index, DS_SET_SIZE(set)));
     }
 }

--- a/src/php/classes/php_vector_ce.c
+++ b/src/php/classes/php_vector_ce.c
@@ -204,11 +204,15 @@ METHOD(slice)
 {
     ds_vector_t *vector = THIS_DS_VECTOR();
 
-    if (ZEND_NUM_ARGS() > 1) {
-        PARSE_LONG_AND_LONG(index, length);
-        RETURN_DS_VECTOR(ds_vector_slice(vector, index, length));
+    PARSE_LONG_AND_OPTIONAL_ZVAL(index, length);
+
+    if (ZEND_NUM_ARGS() > 1 && Z_TYPE_P(length) != IS_NULL) {
+        if (Z_TYPE_P(length) != IS_LONG) {
+            INTEGER_LENGTH_REQUIRED(length);
+        } else {
+            RETURN_DS_VECTOR(ds_vector_slice(vector, index, Z_LVAL_P(length)));
+        }
     } else {
-        PARSE_LONG(index);
         RETURN_DS_VECTOR(ds_vector_slice(vector, index, vector->size));
     }
 }

--- a/src/php/parameters.h
+++ b/src/php/parameters.h
@@ -44,6 +44,11 @@ zend_long l = 0; \
 zval *z = NULL; \
 PARSE_2("lz", &l, &z)
 
+#define PARSE_LONG_AND_OPTIONAL_ZVAL(l, z) \
+zend_long l = 0; \
+zval *z = NULL; \
+PARSE_2("l|z", &l, &z)
+
 #define PARSE_ZVAL_AND_LONG(z, l) \
 zval *z = NULL; \
 zend_long l = 0; \


### PR DESCRIPTION
Currently the `slice()` methods don't work if the value of `$length` is `null`, eg:

```php
$vec = new \Ds\Vector();
$vec->push(1, 2, 3, 4, 5, 6, 7, 8, 9);

var_dump($vec->slice(2, null));
```
```
PHP Deprecated:  Ds\Vector::slice(): Passing null to parameter #2 ($length) of type ?int is deprecated in /test.php on line 7
PHP Stack trace:
PHP   1. {main}() /test.php:0
PHP   2. Ds\Vector->slice($index = 2, $length = NULL) /test.php:7

Deprecated: Ds\Vector::slice(): Passing null to parameter #2 ($length) of type ?int is deprecated in /test.php on line 7

Call Stack:
    0.0001     402344   1. {main}() /test.php:0
    0.0001     402608   2. Ds\Vector->slice($index = 2, $length = NULL) /test.php:7

/test.php:7:
class Ds\Vector#2 (0) {
}
```

This is inconsistent with how `array_slice()`, and by extension the polyfill work, which treat `null` the same as when no argument is passed: https://3v4l.org/rqsnF . It also makes using a variable harder, eg:

```php
if ($length === null) {
    var_dump($vec->slice(2));
} else {
    var_dump($vec->slice(2, $length));
}
```

This PR proposes allowing passing `null` as the length and treating it the same as when the argument isn't passed.

Tests: https://github.com/php-ds/tests/pull/23