### PR TITLE
ci: run tests on php 8.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           - 8.0.1
           - 8.1snapshot
           - 8.2snapshot
+          - 8.3snapshot
         zts: [on, off]
         opcache: [on, off]
     steps:


### PR DESCRIPTION
PHP 8.3 support was added but not tested yet