### PR TITLE
Fix #200: Segmentation fault merging keys of maps containing maps

### DIFF
--- a/src/ds/ds_htable.c
+++ b/src/ds/ds_htable.c
@@ -705,6 +705,7 @@ void ds_htable_put(ds_htable_t *table, zval *key, zval *value)
     // If found, destruct the current value so that we can replace it.
     if (found) {
         zval_ptr_dtor(&bucket->value);
+        ZVAL_UNDEF(&bucket->value);
     }
 
     if (value) {


### PR DESCRIPTION
In `ds_htable_put` when found is true, but value is NULL, the old bucket->value is not cleared out, resulting in a stale value being stored. This means that further operations will keep destroying the stale zval, resulting in a refcount underflow.