### PR TITLE
Fix #206: Null coalescing operator on Vector make search failed

### DIFF
--- a/src/php/handlers/php_deque_handlers.c
+++ b/src/php/handlers/php_deque_handlers.c
@@ -37,7 +37,7 @@ static zval *php_ds_deque_read_dimension
 
     // If we're accessing by reference we have to create a reference.
     // This is for access like $deque[$a][$b] = $c
-    if (value && type != BP_VAR_R) {
+    if (value && type != BP_VAR_R && type != BP_VAR_IS) {
         ZVAL_MAKE_REF(value);
     }
 

--- a/src/php/handlers/php_map_handlers.c
+++ b/src/php/handlers/php_map_handlers.c
@@ -35,7 +35,7 @@ static zval *php_ds_map_read_dimension
 
         // If we're accessing by reference we have to create a reference.
         // This is for access like $map[$a][$b] = $c
-        if (value && type != BP_VAR_R) {
+        if (value && type != BP_VAR_R && type != BP_VAR_IS) {
             ZVAL_MAKE_REF(value);
         }
 

--- a/src/php/handlers/php_set_handlers.c
+++ b/src/php/handlers/php_set_handlers.c
@@ -20,7 +20,7 @@ static zval *php_ds_set_read_dimension
     }
 
     // Only support read, not write.
-    if (type != BP_VAR_R) {
+    if (type != BP_VAR_R && type != BP_VAR_IS) {
         return &EG(uninitialized_zval);
     }
 

--- a/src/php/handlers/php_vector_handlers.c
+++ b/src/php/handlers/php_vector_handlers.c
@@ -37,7 +37,7 @@ static zval *php_ds_vector_read_dimension
 
     // If we're accessing by reference we have to create a reference.
     // This is for access like $deque[$a][$b] = $c
-    if (value && type != BP_VAR_R) {
+    if (value && type != BP_VAR_R && type != BP_VAR_IS) {
         ZVAL_MAKE_REF(value);
     }
 


### PR DESCRIPTION
This happens because php_ds_vector_read_dimension makes a REF from the value when type is not BP_VAR_R. So when the type is BP_VAR_IS then we see the first element becomes a reference. You can see this when doing var_dump.