### PR TITLE
Add support for PIE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
     "name": "php-ds/extension",
+    "description": "An extension providing efficient data structures for PHP 7",
+    "type": "php-ext",
     "license": "MIT",
     "keywords": [],
     "authors": [
@@ -9,11 +11,17 @@
         }
     ],
     "minimum-stability": "dev",
+    "require": {
+        "php": ">= 7.4.0"
+    },
     "require-dev": {
         "php-ds/tests": "^1.5"
     },
     "scripts": {
         "test"   : "php test.php",
         "memtest": "USE_ZEND_ALLOC=0 ZEND_DONT_UNLOAD_MODULES=1 valgrind php test.php"
+    },
+    "php-ext": {
+        "extension-name": "ds"
     }
 }


### PR DESCRIPTION
Adds support for [PIE](https://github.com/php/pie).

Once merged, a maintainer would need to add this repo's URL to https://packagist.org/packages/submit :)

More info/documentation can be read on: https://github.com/php/pie/blob/main/docs/extension-maintainers.md
