### PR TITLE
Replace zend_parse_parameter() call to zend_parse_arg_long()

### DIFF
--- a/src/php/handlers/php_seq_handlers.c
+++ b/src/php/handlers/php_seq_handlers.c
@@ -84,7 +84,7 @@ static void php_ds_seq_unset_dimension
 
     } else if (Z_TYPE_P(offset) == IS_NULL) {
         index = 0;
-        php_docref_error(E_DEPRECATED, "Using null as array offset is deprecated");
+        php_docref_error(NULL, E_DEPRECATED, "Using null as array offset is deprecated");
     } else if (!zend_parse_arg_long(offset, &index, &is_null, false, 0)) {
         INTEGER_INDEX_REQUIRED(offset);
         return;

--- a/src/php/handlers/php_seq_handlers.c
+++ b/src/php/handlers/php_seq_handlers.c
@@ -76,15 +76,18 @@ static void php_ds_seq_unset_dimension
     ds_seq_separate(&php_obj->seq);
     ds_seq_t *seq = php_obj->seq;
     zend_long index = 0;
+    bool is_null = false;
     ZVAL_DEREF(offset);
 
     if (Z_TYPE_P(offset) == IS_LONG) {
         index = Z_LVAL_P(offset);
 
-    } else {
-        if (zend_parse_parameter(ZEND_PARSE_PARAMS_QUIET, 1, offset, "l", &index) == FAILURE) {
-            return;
-        }
+    } else if (Z_TYPE_P(offset) == IS_NULL) {
+        index = 0;
+        php_docref_error(E_DEPRECATED, "Using null as array offset is deprecated");
+    } else if (!zend_parse_arg_long(offset, &index, &is_null, false, 0) {
+        INTEGER_INDEX_REQUIRED(z);
+        return;
     }
 
     if (ds_seq_index_exists(seq, index)) {

--- a/src/php/handlers/php_seq_handlers.c
+++ b/src/php/handlers/php_seq_handlers.c
@@ -85,8 +85,8 @@ static void php_ds_seq_unset_dimension
     } else if (Z_TYPE_P(offset) == IS_NULL) {
         index = 0;
         php_docref_error(E_DEPRECATED, "Using null as array offset is deprecated");
-    } else if (!zend_parse_arg_long(offset, &index, &is_null, false, 0) {
-        INTEGER_INDEX_REQUIRED(z);
+    } else if (!zend_parse_arg_long(offset, &index, &is_null, false, 0)) {
+        INTEGER_INDEX_REQUIRED(offset);
         return;
     }
 


### PR DESCRIPTION
ext-ds is effectively the only caller of this API, API that I'm attempting to remove from the engine.

To parse a single argument it is usually better to just use the `zend_parse_arg_TYPE()` functions.